### PR TITLE
feat: Add param tags to ACL and allow find all resources by some field

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ consumer.jwts
 
 acl = Kong::Acl.new({
   consumer_id: 'a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4',
-  group: 'group1',,
+  group: 'group1',
   tags: ["tag1", "tag2"]
 })
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Kong::Consumer.list(filters)
 Kong::Consumer.all()
 Kong::Consumer.find(id)
 Kong::Consumer.find_by_*(value)
+Kong::Consumer.find_all_by_*(value)
 Kong::Consumer.create(attributes)
 
 consumer = Kong::Consumer.new({ username: 'test-user' })
@@ -262,7 +263,8 @@ consumer.jwts
 
 acl = Kong::Acl.new({
   consumer_id: 'a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4',
-  group: 'group1'
+  group: 'group1',,
+  tags: ["tag1", "tag2"]
 })
 
 acl.create

--- a/lib/kong/acl.rb
+++ b/lib/kong/acl.rb
@@ -2,7 +2,7 @@ module Kong
   class Acl
     include Base
     include BelongsToConsumer
-    ATTRIBUTE_NAMES = %w(id group consumer_id).freeze
+    ATTRIBUTE_NAMES = %w(id group tags consumer_id).freeze
     API_END_POINT = "/acls/".freeze
   end
 end

--- a/lib/kong/base.rb
+++ b/lib/kong/base.rb
@@ -37,6 +37,13 @@ module Kong
           else
             super
           end
+        elsif method.to_s.start_with?('find_all_by_')
+          attribute = method.to_s.sub('find_all_by_', '')
+          if self.attribute_names.include?(attribute)
+            self.list({ attribute => arguments[0] })
+          else
+            super
+          end
         else
           super
         end
@@ -45,6 +52,13 @@ module Kong
       def respond_to?(method, include_private = false)
         if method.to_s.start_with?('find_by_')
           attribute = method.to_s.sub('find_by_', '')
+          if self.attribute_names.include?(attribute)
+            return true
+          else
+            super
+          end
+        elsif method.to_s.start_with?('find_all_by_')
+          attribute = method.to_s.sub('find_all_by_', '')
           if self.attribute_names.include?(attribute)
             return true
           else

--- a/spec/kong/acl_spec.rb
+++ b/spec/kong/acl_spec.rb
@@ -2,7 +2,7 @@ require_relative "../spec_helper"
 
 describe Kong::Acl do
   let(:valid_attribute_names) do
-    %w(id group consumer_id)
+    %w(id group tags consumer_id)
   end
 
   describe '::ATTRIBUTE_NAMES' do

--- a/spec/kong/base_spec.rb
+++ b/spec/kong/base_spec.rb
@@ -51,11 +51,19 @@ describe Kong::Base do
       it 'will respond to find_by_* methods' do
         expect(Klass.respond_to?(:find_by_name)).to be_truthy
       end
+
+      it 'will respond to find_all_by_* methods' do
+        expect(Klass.respond_to?(:find_all_by_name)).to be_truthy
+      end
     end
 
     context 'when attribute does not exit' do
       it 'will not respond to find_by_* methods' do
         expect(Klass.respond_to?(:find_by_invalid)).to be_falsey
+      end
+
+      it 'will not respond to find_all_by_* methods' do
+        expect(Klass.respond_to?(:find_all_by_invalid)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Adicionando 2 funcionalidades nova a LIB:

- Permitindo criar ACLs e procurar pelo campo TAGS
- Permitindo procurar todos os itens de um recurso pela função find_all_by.

## Testes

### Requisitos

Algum servidor KONG rodando.

Para definir a URL do kong, basta preencher a varíavel de ambiente `ENV['KONG_URI']`.
Caso esteja rodando no `'http://localhost:8001'` não precisa fazer nenhum alteração.

<details>
<summary>Testando criação de ACL com tags</summary>

#### Passos

1. Rodar o projeto. Ex: `irb -r ./lib/kong.rb`
2. Tenha em mãos um ID de um consumer que você deseja adicionar o ACL.
**Dica:** Para facilitar, você pode pegar o primeiro da lista rodando `Kong::Consumer.list.first.id`
3. Rode o comando para criar um ACL para esse consumer com tags:
```Kong::Acl.create({
   consumer: { id: '{ID_CONSUMER}' },
   group: 'group1',
   tags: ["tag1", "tag2"]
})
```
4. Verifique se o ACL foi criado corretamente para o Consumer
```Kong::Consumer.find("3c18a510-0f78-4e9e-bacf-a9b682c77c0d").acls```

**Resultado esperado:** ACL tenha sido criado corretamente com as tags.
</details>

<details>
<summary>Testando consulta de itens de algum recurso</summary>

#### Passos

1. Rodar o projeto. Ex: `irb -r ./lib/kong.rb`
2. Tenha em mãos uma "TAG" que você deseja consultar todos os ACLs existentes com ela.
**Dica:** Para facilitar, você pode utilizar a tag "tag_2" utilizada no exemplo acima.
3. Rode o comando para criar um ACL para esse consumer com tags:
``
Kong::Acl.find_all_by_tags("tag2")
```

**Resultado esperado:** Retorne todos os ACLs existente com essa tag.
</details>

